### PR TITLE
Fix bug requiring PostgresSQL on system

### DIFF
--- a/tutorials/tutorial_requirements.txt
+++ b/tutorials/tutorial_requirements.txt
@@ -16,7 +16,12 @@ joblib
 planetary_computer
 stackstac
 stac_validator
-odc-algo==0.2.3
-odc-geo==0.3.3
+psycopg2-binary~=2.9.10
+odc-algo
+odc-geo
+odc-stac
 jupyterlab
 cftime
+boto3
+folium
+netCDF4


### PR DESCRIPTION
The current `tutorial_requirements.txt` requires an installation of PostgresSQL to run the examples. I modified the file so `psycopg2-binary` is installed rather than the version requiring PostgresSQL. Additionally, I added a few packages that are required to run the Sentinel1, Sentinel2, and Sentinel5 tutorials. I could not submit a PR through my enterprise account